### PR TITLE
Fix issue with Version Tree not loading

### DIFF
--- a/clearcase.py
+++ b/clearcase.py
@@ -27,7 +27,7 @@ class ClearcaseCheckinCommand(ClearcaseCommand):
 
 class ClearcaseVtreeCommand(ClearcaseCommand):
     def run(self):
-        cmd = ['clearvtree', self.window.active_view().file_name()]
+        cmd = ['cleartool', 'lsvtree', '-graphical', self.window.active_view().file_name()]
         super(ClearcaseVtreeCommand, self).run(cmd)
 
 class ClearcasePrevCommand(ClearcaseCommand):


### PR DESCRIPTION
I had a problem opening the clearcase version tree from inside sublime. The version tree UI would appear and began to load and then just disappear before the tree became visible.

Changing the command seems to have fixed the problem although I'm not sure why:
Now using:
cleartool lsvtree -graphical <file_path>
Instead of:
clearvtree <file_path>

Sublime Version 2.0.1 Build 2217
Clearcase Version 7.0.1.12
