### PR TITLE
Make clearcase commands appear in the command palette

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,9 @@
+[
+  { "command": "clearcase_explorer", "caption": "Clearcase: Explorer" },
+  { "command": "clearcase_checkout", "caption": "Clearcase: Checkout" },
+  { "command": "clearcase_checkin", "caption": "Clearcase: Checkin" },
+  { "command": "clearcase_vtree", "caption": "Clearcase: Version Tree" },
+  { "command": "clearcase_prev", "caption": "Clearcase: Compare Previous" },
+  { "command": "clearcase_unco", "caption": "Clearcase: Undo Checkout" },
+  { "command": "clearcase_annotate", "caption": "Clearcase: Annotate" }
+]


### PR DESCRIPTION
I just added a file to make the clearcase commands show up in the command palette and changed the capitalisation caption style to match the sublime standard.
